### PR TITLE
Version 3.4.3: Fix absolute XPath scoping in PlayElement._get_base()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <br>
 
+## v3.4.3
+
+### Fixed
+- `PlayElement._get_base()` now bypasses parent scoping for absolute XPath locators (`xpath=//...`), preventing Playwright's subtree restriction from silently narrowing element searches
+
+---
+
 ## v3.4.2
 *Release date: 2026-03-28*
 

--- a/mops/__init__.py
+++ b/mops/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '3.4.2'
+__version__ = '3.4.3'
 __project_name__ = 'mops'

--- a/mops/playwright/play_element.py
+++ b/mops/playwright/play_element.py
@@ -429,10 +429,20 @@ class PlayElement(ElementABC, Logging, ABC):
 
     def _get_base(self) -> Union[PlaywrightPage, Locator]:
         """
-        Get driver depends on parent element if available
+        Get driver depends on parent element if available.
 
-        :return: driver
+        For absolute XPath locators (starting with ``xpath=//``), always returns
+        the page-level driver to avoid Playwright's subtree scoping behavior.
+        Playwright's ``Locator.locator()`` restricts ``//`` searches to the parent's
+        DOM subtree, which contradicts XPath semantics where ``//`` means
+        "anywhere in the document".
+
+        :return: driver or parent element
+        :rtype: Union[PlaywrightPage, Locator]
         """
+        if isinstance(self.locator, str) and self.locator.startswith("xpath=//"):
+            return self.driver
+
         base = self.driver
         if self.parent:
             self.log(f'Get element "{self.name}" from parent element "{self.parent.name}"', level='debug')

--- a/tests/static_tests/unit/test_get_base_xpath.py
+++ b/tests/static_tests/unit/test_get_base_xpath.py
@@ -1,0 +1,69 @@
+import pytest
+
+from mops.base.element import Element
+from mops.base.group import Group
+
+
+class ParentGroup(Group):
+    def __init__(self):
+        super().__init__('//div[@id="parent"]')
+
+    absolute_xpath_child = Element('//span[@class="target"]')
+    relative_xpath_child = Element('.//span[@class="target"]')
+    css_child = Element('#target')
+    parenthesized_xpath_child = Element('(//div)[1]//span')
+
+
+@pytest.fixture
+def group(mocked_play_driver):
+    return ParentGroup()
+
+
+def test_absolute_xpath_bypasses_parent_scoping(group):
+    """Absolute XPath locator should resolve from page root, not from parent subtree."""
+    child = group.absolute_xpath_child
+    base = child._get_base()
+    assert base == child.driver, (
+        f"Expected page-level driver for absolute XPath, got {type(base)}"
+    )
+
+
+def test_relative_xpath_scoped_to_parent(group):
+    """Relative XPath locator should chain through parent element."""
+    child = group.relative_xpath_child
+    base = child._get_base()
+    assert base != child.driver, (
+        "Expected parent Locator for relative XPath, got page-level driver"
+    )
+
+
+def test_css_locator_scoped_to_parent(group):
+    """CSS locator should chain through parent element."""
+    child = group.css_child
+    base = child._get_base()
+    assert base != child.driver, (
+        "Expected parent Locator for CSS selector, got page-level driver"
+    )
+
+
+def test_parenthesized_xpath_scoped_to_parent(group):
+    """Parenthesized XPath like (//div)[1]//span should chain through parent."""
+    child = group.parenthesized_xpath_child
+    base = child._get_base()
+    assert base != child.driver, (
+        "Expected parent Locator for parenthesized XPath, got page-level driver"
+    )
+
+
+def test_absolute_xpath_without_parent(mocked_play_driver):
+    """Standalone element with absolute XPath should return driver regardless."""
+    el = Element('//div[@id="solo"]', parent=False)
+    base = el._get_base()
+    assert base == el.driver
+
+
+def test_element_without_parent_returns_driver(mocked_play_driver):
+    """Element with no parent always returns driver, regardless of locator type."""
+    el = Element('.some-class', parent=False)
+    base = el._get_base()
+    assert base == el.driver


### PR DESCRIPTION
## Summary

- **Fix `PlayElement._get_base()`** to bypass parent Locator scoping for absolute XPath locators (`xpath=//...`)
- Playwright's `Locator.locator()` restricts `//` searches to the parent's DOM subtree, contradicting XPath semantics where `//` means "anywhere in the document"
- Relative XPaths (`.//`, `(//`), CSS, and all other locator types continue to chain through parent elements — no behavior change for them

## Problem

When an `Element` with an absolute XPath locator (e.g. `xpath=//h1[.='Dashboard']`) is nested inside a `Group`, `_get_base()` returns the parent's `Locator` object. Playwright then scopes the `//` search to the parent's subtree instead of the full page DOM. This causes silent failures: elements are either not found or the wrong element is matched.

## Fix

Added an early return in `_get_base()`: if the element's locator starts with `xpath=//`, return `self.driver` (the Page object) instead of the parent Locator. This is safe because:

1. `set_playwright_locator()` normalizes all XPath locators to `xpath=//...` format
2. Relative XPaths (`.//child`) become `xpath=.//child` — do NOT match
3. Parenthesized XPaths (`(//parent)//child`) become `xpath=(//...` — do NOT match
4. Selenium/Appium are unaffected — `PlayElement._get_base()` is Playwright-only

## Test plan

- [x] Added 6 unit tests in `tests/static_tests/unit/test_get_base_xpath.py`:
  - `test_absolute_xpath_bypasses_parent_scoping` — absolute XPath returns page driver
  - `test_relative_xpath_scoped_to_parent` — relative XPath chains through parent
  - `test_css_locator_scoped_to_parent` — CSS chains through parent
  - `test_parenthesized_xpath_scoped_to_parent` — parenthesized XPath chains through parent
  - `test_absolute_xpath_without_parent` — standalone element returns driver
  - `test_element_without_parent_returns_driver` — no-parent element returns driver
- [x] All 373 static tests pass
- [x] No linter errors
- [x] Version bumped to 3.4.3, CHANGELOG updated


Made with [Cursor](https://cursor.com)